### PR TITLE
[hotfix] Fixes busy-wait factor 1000 in RedisLockingCacheObserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 
+## 3.2.3 - 2020-09-30
+### Fixed
+- Fixes bug in `RedisLockingCacheObserver` where the busy-wait would wait 1000 times
+  as short, resulting in 1000 times the number of Redis checks, causing a large CPU spike
+  to occur whenever the lock could not be obtained.
+
+  [usleep](https://www.php.net/manual/en/function.usleep.php) expects a value in microseconds,
+  i.e. this means that 1,000,000 equals 1 seconds.  We were calling `usleep` with, on average,
+  150 microseconds.  This should have been 150,000 microseconds.
+
+  'Fun fact'... The `RedisLockingCacheObserver`, and this bug, was introduced over two years
+  ago in 2018-06-26... and has been causing occasional problems ever since.
+
 ## 3.2.2 - 2020-07-17
 ### Fixed
 - The `RedisLockingCacheObserver` would always unlock, even when the lock should have been
   maintained.  This fixes a bug introduced in version 3.1.2.
 - To reduce CPU and traffic usage during busy-wait, the `RedisLockingCacheObserver` will has
   increased the default `$minLockSleepMicroSeconds` and `$maxLockSleepMicroSeconds` times.
-- To reduce the maximum time a process will busy-wait, the `$minLockTTLSeconds` was reduced. 
+- To reduce the maximum time a process will busy-wait, the `$minLockTTLSeconds` was reduced.
 - Rename variables to clearly indicate whether their values are in seconds or microseconds.
 - Add unit tests to verify the behavior of the `RedisLockingCacheObserver`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 
+## 3.2.4 - 2020-10-01
+### Fixed
+- Fixes naming confusion.  The variables are called '$...micoseconds' and hence their
+  value should be in microseconds.
+
 ## 3.2.3 - 2020-09-30
 ### Fixed
 - Fixes bug in `RedisLockingCacheObserver` where the busy-wait would wait 1000 times

--- a/src/Zicht/Service/Common/Observers/RedisLockingCacheObserver.php
+++ b/src/Zicht/Service/Common/Observers/RedisLockingCacheObserver.php
@@ -25,10 +25,10 @@ class RedisLockingCacheObserver extends RedisCacheObserver
     protected $minLockTTLSeconds = 3;
 
     /** @var int */
-    protected $minLockSleepMicroSeconds = 100;
+    protected $minLockSleepMicroSeconds = 100000;
 
     /** @var int */
-    protected $maxLockSleepMicroSeconds = 200;
+    protected $maxLockSleepMicroSeconds = 200000;
 
     /**
      * @param integer $minLockTTL in seconds
@@ -38,8 +38,8 @@ class RedisLockingCacheObserver extends RedisCacheObserver
     public function configure($minLockTTL, $minLockSleepSeconds, $maxLockSleepSeconds)
     {
         $this->minLockTTLSeconds = $minLockTTL;
-        $this->minLockSleepMicroSeconds = $minLockSleepSeconds * 1000;
-        $this->maxLockSleepMicroSeconds = $maxLockSleepSeconds * 1000;
+        $this->minLockSleepMicroSeconds = $minLockSleepSeconds * 1000000;
+        $this->maxLockSleepMicroSeconds = $maxLockSleepSeconds * 1000000;
     }
 
     /**
@@ -158,7 +158,7 @@ class RedisLockingCacheObserver extends RedisCacheObserver
     {
         $attemptCounter = 1;
         while (!($res = $redis->set($lockKey, $token, ['nx', 'ex' => $ttlSeconds]))) {
-            usleep(mt_rand($this->minLockSleepMicroSeconds, $this->maxLockSleepMicroSeconds) * 1000);
+            usleep(mt_rand($this->minLockSleepMicroSeconds, $this->maxLockSleepMicroSeconds));
             $attemptCounter++;
         }
 

--- a/src/Zicht/Service/Common/Observers/RedisLockingCacheObserver.php
+++ b/src/Zicht/Service/Common/Observers/RedisLockingCacheObserver.php
@@ -158,7 +158,7 @@ class RedisLockingCacheObserver extends RedisCacheObserver
     {
         $attemptCounter = 1;
         while (!($res = $redis->set($lockKey, $token, ['nx', 'ex' => $ttlSeconds]))) {
-            usleep(mt_rand($this->minLockSleepMicroSeconds, $this->maxLockSleepMicroSeconds));
+            usleep(mt_rand($this->minLockSleepMicroSeconds, $this->maxLockSleepMicroSeconds) * 1000);
             $attemptCounter++;
         }
 


### PR DESCRIPTION
Already tagged to prepare releases for TTC and TTV