### PR TITLE
[IFFR-687] Revert "Update dependensies"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added|Changed|Deprecated|Removed|Fixed|Security
 
+## 3.2.5 - 2020-12-28
+### Fixed
+- Reverted 3.2.1.  The current code (see AbstractRest.php) is not compatible with
+  guzzle 6+.
+
 ## 3.2.4 - 2020-10-01
 ### Fixed
 - Fixes naming confusion.  The variables are called '$...micoseconds' and hence their

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "guzzlehttp/guzzle": "^4 | ^5 | ^6"
+        "guzzlehttp/guzzle": "^4 | ^5"
     },
     "require-dev": {
         "monolog/monolog": "^1.24",


### PR DESCRIPTION
This reverts commit 9aa6c19aac357a06c950867a2dcac090312845a0.

Ik verwacht dat we een nieuwe versie (op release 3) moeten maken die wel compatible is met guzzle 6 en of 7.